### PR TITLE
fails to build with text-1.1.0.0

### DIFF
--- a/hashabler.cabal
+++ b/hashabler.cabal
@@ -65,7 +65,7 @@ library
   build-depends:       base >=4.4 && <5
                      , array
                      , bytestring
-                     , text
+                     , text >= 1.1.1.3
                      , primitive
                      , ghc-prim
                      -- For endianness test:


### PR DESCRIPTION
with text-1.1.0.0, I get:

```
src/Data/Hashabler.hs:1088:24:
    Not in scope: data constructor ‘T.Array’
    Perhaps you meant ‘P.Array’ (imported from Data.Primitive)
```

It appears that the first version of text to expose the Array constructor in Data.Text.Array is 1.1.1.3.  After adding this constraint, cabal grabs text-1.2.0.4 for me, and it builds fine.
